### PR TITLE
Test cleanup, generic child channel

### DIFF
--- a/common/src/main/java/network/ycc/raknet/channel/DatagramChannelProxy.java
+++ b/common/src/main/java/network/ycc/raknet/channel/DatagramChannelProxy.java
@@ -23,6 +23,7 @@ import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 
+import java.lang.reflect.InvocationTargetException;
 import java.net.PortUnreachableException;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
@@ -49,9 +50,9 @@ public class DatagramChannelProxy implements Channel {
 
     public DatagramChannelProxy(Class<? extends DatagramChannel> ioChannelType) {
         this(() -> {
-            try {
-                return ioChannelType.newInstance();
-            } catch (InstantiationException | IllegalAccessException e) {
+            try {	
+                return ioChannelType.getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                 throw new IllegalArgumentException("Failed to create instance", e);
             }
         });

--- a/common/src/main/java/network/ycc/raknet/channel/DatagramChannelProxy.java
+++ b/common/src/main/java/network/ycc/raknet/channel/DatagramChannelProxy.java
@@ -50,7 +50,7 @@ public class DatagramChannelProxy implements Channel {
 
     public DatagramChannelProxy(Class<? extends DatagramChannel> ioChannelType) {
         this(() -> {
-            try {	
+            try {
                 return ioChannelType.getDeclaredConstructor().newInstance();
             } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                 throw new IllegalArgumentException("Failed to create instance", e);

--- a/common/src/main/java/network/ycc/raknet/config/DefaultConfig.java
+++ b/common/src/main/java/network/ycc/raknet/config/DefaultConfig.java
@@ -36,7 +36,7 @@ public class DefaultConfig extends DefaultChannelConfig implements RakNet.Config
     private volatile RakNet.Codec codec = DefaultCodec.INSTANCE;
     private volatile int[] protocolVersions = new int[]{9, 10};
     private volatile int maxConnections = 2048;
-    private volatile int protocolVersion;
+    private volatile int protocolVersion = 9;
 
     public DefaultConfig(Channel channel) {
         super(channel);

--- a/common/src/test/java/network/ycc/raknet/utils/UINTTests.java
+++ b/common/src/test/java/network/ycc/raknet/utils/UINTTests.java
@@ -1,14 +1,13 @@
 package network.ycc.raknet.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
 import it.unimi.dsi.fastutil.ints.IntBidirectionalIterator;
 import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
 import it.unimi.dsi.fastutil.ints.IntSortedSet;
-import org.junit.Test;
 
 public class UINTTests {
     @Test
@@ -19,7 +18,7 @@ public class UINTTests {
             int d = (int) (random.nextDouble() * UINT.B3.MAX_VALUE) - UINT.B3.HALF_MAX;
             int b = UINT.B3.plus(a, d);
 
-            assertEquals(UINT.B3.minusWrap(b, a), d);
+            Assertions.assertEquals(UINT.B3.minusWrap(b, a), d);
         }
     }
 
@@ -37,7 +36,7 @@ public class UINTTests {
             }
         }
 
-        assertTrue(hasFailed);
+        Assertions.assertTrue(hasFailed);
     }
 
     @Test
@@ -54,7 +53,7 @@ public class UINTTests {
         while (itr.hasNext()) {
             int next = itr.nextInt();
             int d = UINT.B3.minusWrap(x, next);
-            assertTrue(d <= 0);
+            Assertions.assertTrue(d <= 0);
             x = next;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/server/src/main/java/network/ycc/raknet/server/pipeline/ConnectionInitializer.java
+++ b/server/src/main/java/network/ycc/raknet/server/pipeline/ConnectionInitializer.java
@@ -59,7 +59,6 @@ public class ConnectionInitializer extends AbstractConnectionInitializer {
                     seenFirst = true;
 
                     if (!config.containsProtocolVersion(cr1.getProtocolVersion())) {
-                        System.out.println("Unmatching protocol versions");
                         final InvalidVersion packet = new InvalidVersion(config.getMagic(), config.getServerId());
                         ctx.writeAndFlush(packet).addListener(ChannelFutureListener.CLOSE);
                         return;

--- a/tests/src/test/java/network/ycc/raknet/BehaviorTest.java
+++ b/tests/src/test/java/network/ycc/raknet/BehaviorTest.java
@@ -1,5 +1,8 @@
 package network.ycc.raknet;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import network.ycc.raknet.client.RakNetClient;
 import network.ycc.raknet.config.DefaultMagic;
 import network.ycc.raknet.packet.FrameSet;
@@ -22,9 +25,6 @@ import io.netty.handler.codec.CorruptedFrameException;
 
 import java.net.InetSocketAddress;
 import java.nio.channels.UnsupportedAddressTypeException;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 public class BehaviorTest {
     final EventLoopGroup ioGroup = new NioEventLoopGroup();
@@ -52,7 +52,7 @@ public class BehaviorTest {
                     .connect(localhostIPv6).sync().channel();
 
             try {
-                Assert.assertTrue(clientChannel.isActive());
+                Assertions.assertTrue(clientChannel.isActive());
             } finally {
                 serverChannel.close().sync();
                 clientChannel.close().sync();
@@ -62,7 +62,7 @@ public class BehaviorTest {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test()
     public void badMagicClient() throws Throwable {
         final Channel serverChannel = new ServerBootstrap()
                 .group(ioGroup, childGroup)
@@ -80,12 +80,14 @@ public class BehaviorTest {
 
         final Channel clientChannel = clientConnect.channel();
 
-        try {
-            clientConnect.sync();
-        } finally {
-            serverChannel.close().sync();
-            clientChannel.close().sync();
-        }
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            try {
+                clientConnect.sync();
+            } finally {
+                serverChannel.close().sync();
+                clientChannel.close().sync();
+            }
+        });
     }
 
     /*@Test(expected = IllegalStateException.class)
@@ -113,7 +115,7 @@ public class BehaviorTest {
         }
     }*/
 
-    @Test(expected = ConnectTimeoutException.class)
+    @Test()
     public void badConnect() throws Throwable {
         final Channel serverChannel = new Bootstrap()
                 .group(ioGroup)
@@ -130,15 +132,16 @@ public class BehaviorTest {
 
         final Channel clientChannel = clientConnect.channel();
 
-        try {
-            clientConnect.sync();
-        } finally {
-            serverChannel.close().sync();
-            clientChannel.close().sync();
-        }
+        Assertions.assertThrows(ConnectTimeoutException.class, () -> {
+            try {
+                clientConnect.sync();
+            } finally {
+                serverChannel.close().sync();
+                clientChannel.close().sync();
+            }
+        });
     }
 
-    @Test(expected = InvalidVersion.InvalidVersionException.class)
     public void badVersionClient() throws Throwable {
         final Channel serverChannel = new ServerBootstrap()
                 .group(ioGroup, childGroup)
@@ -155,15 +158,16 @@ public class BehaviorTest {
 
         final Channel clientChannel = clientConnect.channel();
 
-        try {
-            clientConnect.sync();
-        } finally {
-            serverChannel.close().sync();
-            clientChannel.close().sync();
-        }
+        Assertions.assertThrows(InvalidVersion.InvalidVersionException.class, () -> {
+            try {
+                clientConnect.sync();
+            } finally {
+                serverChannel.close().sync();
+                clientChannel.close().sync();
+            }
+        });
     }
 
-    @Test(expected = InvalidVersion.InvalidVersionException.class)
     public void badVersionServer() throws Throwable {
         final Channel serverChannel = new ServerBootstrap()
                 .group(ioGroup, childGroup)
@@ -180,16 +184,20 @@ public class BehaviorTest {
 
         final Channel clientChannel = clientConnect.channel();
 
-        try {
-            clientConnect.sync();
-        } finally {
-            serverChannel.close().sync();
-            clientChannel.close().sync();
-        }
+        Assertions.assertThrows(InvalidVersion.InvalidVersionException.class, () -> {
+            try {
+                clientConnect.sync();
+            } finally {
+                serverChannel.close().sync();
+                clientChannel.close().sync();
+            }
+        });
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test()
     public void corruptFrameTest() {
-        FrameSet.read(Unpooled.wrappedBuffer(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        Assertions.assertThrows(CorruptedFrameException.class, () -> {
+            FrameSet.read(Unpooled.wrappedBuffer(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        });
     }
 }

--- a/tests/src/test/java/network/ycc/raknet/BehaviorTest.java
+++ b/tests/src/test/java/network/ycc/raknet/BehaviorTest.java
@@ -47,7 +47,6 @@ public class BehaviorTest {
             final Channel clientChannel = new Bootstrap()
                     .group(ioGroup)
                     .channel(RakNetClient.CHANNEL)
-                    .option(RakNet.PROTOCOL_VERSION, 9)
                     .handler(new EmptyInit())
                     .connect(localhostIPv6).sync().channel();
 
@@ -74,7 +73,6 @@ public class BehaviorTest {
                 .group(ioGroup)
                 .channel(RakNetClient.CHANNEL)
                 .option(RakNet.MAGIC, badMagic)
-                .option(RakNet.PROTOCOL_VERSION, 9)
                 .handler(new EmptyInit())
                 .connect(localhost);
 

--- a/tests/src/test/java/network/ycc/raknet/EndToEndTest.java
+++ b/tests/src/test/java/network/ycc/raknet/EndToEndTest.java
@@ -305,7 +305,6 @@ public class EndToEndTest {
                     }
                 }))
                 .option(RakNet.CLIENT_ID, 6789L)
-                .option(RakNet.PROTOCOL_VERSION, 9)
                 .option(RakNet.RETRY_DELAY_NANOS,
                         TimeUnit.NANOSECONDS.convert(10, TimeUnit.MILLISECONDS))
                 .handler(new ChannelInitializer<Channel>() {

--- a/tests/src/test/java/network/ycc/raknet/EndToEndTest.java
+++ b/tests/src/test/java/network/ycc/raknet/EndToEndTest.java
@@ -37,8 +37,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EndToEndTest {
     final EventLoopGroup ioGroup = new NioEventLoopGroup();
@@ -115,7 +115,7 @@ public class EndToEndTest {
         System.gc();
         System.gc();
 
-        Assert.assertEquals(bytesSent, bytesRecvd.get());
+        Assertions.assertEquals(bytesSent, bytesRecvd.get());
     }
 
     @Test
@@ -257,10 +257,10 @@ public class EndToEndTest {
         System.gc();
         System.gc();
         System.gc();
-        Assert.assertTrue(reliableSet.isEmpty());
-        Assert.assertEquals(0, pending.get());
-        Assert.assertEquals(nSend, numRecvd.get());
-        Assert.assertEquals(bytesSent.get(), bytesRecvd.get());
+        Assertions.assertTrue(reliableSet.isEmpty());
+        Assertions.assertEquals(0, pending.get());
+        Assertions.assertEquals(nSend, numRecvd.get());
+        Assertions.assertEquals(bytesSent.get(), bytesRecvd.get());
     }
 
     public Channel newServer(ChannelInitializer<Channel> ioInit,

--- a/tests/src/test/java/network/ycc/raknet/HelloWorld.java
+++ b/tests/src/test/java/network/ycc/raknet/HelloWorld.java
@@ -1,5 +1,8 @@
 package network.ycc.raknet;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import network.ycc.raknet.client.RakNetClient;
 import network.ycc.raknet.pipeline.UserDataCodec;
 import network.ycc.raknet.server.RakNetServer;
@@ -19,9 +22,6 @@ import io.netty.channel.nio.NioEventLoopGroup;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 public class HelloWorld {
 
@@ -72,7 +72,7 @@ public class HelloWorld {
         serverChannel.close().sync();
         clientChannel.close().sync();
 
-        Assert.assertEquals(resultStr, helloWorld);
+        Assertions.assertEquals(resultStr, helloWorld);
     }
 
 }


### PR DESCRIPTION
* Clean up some of the modifications made for version support.
* Modify `RakNetServerChannel` to track generic child types instead of specifically `RakNetChildChannel`.
* Switch to JUnit 5.